### PR TITLE
add ability to define Bluetooth adaptor

### DIFF
--- a/pyftms/client/__init__.py
+++ b/pyftms/client/__init__.py
@@ -40,6 +40,7 @@ def get_client(
     adv_or_type: AdvertisementData | MachineType,
     *,
     timeout: float = 2,
+    ble_adapter: str = "hci0",
     on_ftms_event: FtmsCallback | None = None,
     on_disconnect: DisconnectCallback | None = None,
 ) -> FitnessMachine:
@@ -70,6 +71,7 @@ def get_client(
         ble_device,
         adv_data,
         timeout=timeout,
+        ble_adapter=ble_adapter,
         on_ftms_event=on_ftms_event,
         on_disconnect=on_disconnect,
     )
@@ -77,6 +79,7 @@ def get_client(
 
 async def discover_ftms_devices(
     discover_time: float = 10,
+    ble_adapter: str = "hci0",
 ) -> AsyncIterator[tuple[BLEDevice, MachineType]]:
     """
     Discover FTMS devices.
@@ -90,7 +93,7 @@ async def discover_ftms_devices(
 
     devices: set[str] = set()
 
-    async with BleakScanner() as scanner:
+    async with BleakScanner(adapter=ble_adapter) as scanner:
         try:
             async with asyncio.timeout(discover_time):
                 async for dev, adv in scanner.advertisement_data():
@@ -123,6 +126,7 @@ async def get_client_from_address(
     address: str,
     *,
     scan_timeout: float = 10,
+    ble_adapter: str = "hci0",
     timeout: float = 2,
     on_ftms_event: FtmsCallback | None = None,
     on_disconnect: DisconnectCallback | None = None,
@@ -141,7 +145,7 @@ async def get_client_from_address(
     - `FitnessMachine` instance if device found successfully.
     """
 
-    async for dev, machine_type in discover_ftms_devices(scan_timeout):
+    async for dev, machine_type in discover_ftms_devices(scan_timeout, ble_adapter):
         if dev.address.lower() == address.lower():
             return get_client(
                 dev,

--- a/pyftms/client/client.py
+++ b/pyftms/client/client.py
@@ -81,6 +81,7 @@ class FitnessMachine(ABC, PropertiesManager):
         adv_data: AdvertisementData | None = None,
         *,
         timeout: float = 2.0,
+        ble_adapter: str = "hci0",
         on_ftms_event: FtmsCallback | None = None,
         on_disconnect: DisconnectCallback | None = None,
     ) -> None:


### PR DESCRIPTION
add ability to define Bluetooth adaptor in 'get_client', 'get_client_by_address' and 'discover_ftms_devices'. Aim is to foreward the ftms to a second device.
Usecase(1):
- connect to ftms-device via hci0.
- foreward training data via Ant+ device to Garmin watch.
- connect to mobile via hci1 to controll the ftms on hci0

Usecase(2):
- use different adaptor, when build in adaptor doesn't work with ftms