### PR TITLE
Add Bodytone DU30-B1D8 Fitness Bike

### DIFF
--- a/diagnose_bt.py
+++ b/diagnose_bt.py
@@ -1,0 +1,70 @@
+"""
+Bluetooth diagnostic script.
+Scans ALL nearby BLE devices (no UUID filter) and shows advertisement details.
+Run with: python diagnose_bt.py
+"""
+
+import asyncio
+from bleak import BleakScanner
+from bleak.uuids import normalize_uuid_str
+
+FTMS_UUID = normalize_uuid_str("1826")
+SCAN_TIME = 10  # seconds
+
+
+async def main():
+    print(f"Scanning ALL BLE devices for {SCAN_TIME}s (no filter)...\n")
+
+    found = {}
+
+    def callback(device, adv):
+        if device.address not in found:
+            found[device.address] = (device, adv)
+
+    async with BleakScanner(detection_callback=callback):
+        await asyncio.sleep(SCAN_TIME)
+
+    if not found:
+        print("No BLE devices found at all.")
+        print("Possible causes:")
+        print("  - Bluetooth adapter not available")
+        print("  - BlueZ not running (check: sudo systemctl status bluetooth)")
+        print("  - Home Assistant holding exclusive access to the adapter")
+        return
+
+    print(f"Found {len(found)} BLE device(s):\n")
+
+    ftms_devices = []
+
+    for addr, (dev, adv) in sorted(found.items()):
+        has_ftms = FTMS_UUID in (adv.service_uuids or [])
+        marker = "  <-- FTMS (fitness machine!)" if has_ftms else ""
+        print(f"  [{addr}] {dev.name or '(no name)'}{marker}")
+        print(f"    RSSI: {adv.rssi} dBm")
+        if adv.service_uuids:
+            print(f"    Service UUIDs: {list(adv.service_uuids)}")
+        if adv.service_data:
+            print(f"    Service Data:  {adv.service_data}")
+        if adv.manufacturer_data:
+            mfr = {k: v.hex() for k, v in adv.manufacturer_data.items()}
+            print(f"    Manufacturer:  {mfr}")
+        print()
+
+        if has_ftms:
+            ftms_devices.append((dev, adv))
+
+    print("-" * 60)
+    if ftms_devices:
+        print(f"FTMS devices found: {len(ftms_devices)}")
+        for dev, adv in ftms_devices:
+            has_service_data = FTMS_UUID in (adv.service_data or {})
+            print(f"  {dev.address} ({dev.name})")
+            print(f"    Has FTMS service data: {has_service_data}")
+            if not has_service_data:
+                print("    NOTE: No FTMS service data -> requires GATT fallback")
+    else:
+        print("No FTMS devices found in the raw scan.")
+        print("Check that the bike is powered on and in Bluetooth range.")
+
+
+asyncio.run(main())

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,4 @@
+# PowerShell
+
+usbipd list
+usbipd attach --wsl --busid 2-5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.15"
 dependencies = [
     "bleak >= 0.21",
     "bleak-retry-connector >= 3.5",
@@ -34,6 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]

--- a/src/pyftms/client/__init__.py
+++ b/src/pyftms/client/__init__.py
@@ -98,15 +98,26 @@ async def discover_ftms_devices(
     """
 
     devices: set[str] = set()
+    ftms_uuid = normalize_uuid_str(FTMS_UUID)
 
-    async with BleakScanner(
-        service_uuids=[normalize_uuid_str(FTMS_UUID)],
-        kwargs=kwargs,
-    ) as scanner:
+    # Scan without a service_uuids filter: on Linux/BlueZ the hardware-level
+    # UUID filter only matches devices that include FTMS data in the service
+    # data field of their advertisement.  Some devices (e.g. Bodytone DU30)
+    # advertise the FTMS UUID in service_uuids but provide no service data, so
+    # they would be silently dropped.  We therefore scan for all BLE devices
+    # and filter manually.
+    async with BleakScanner(**kwargs) as scanner:
         try:
             async with asyncio.timeout(discover_time):
                 async for dev, adv in scanner.advertisement_data():
                     if dev.address in devices:
+                        continue
+
+                    # Quick pre-filter: skip devices that have no FTMS UUID
+                    # in either service_data or service_uuids.
+                    if ftms_uuid not in adv.service_data and ftms_uuid not in (
+                        adv.service_uuids or ()
+                    ):
                         continue
 
                     try:
@@ -117,9 +128,6 @@ async def discover_ftms_devices(
                         # not include machine type in its service data (e.g.
                         # Bodytone DU30). Fall back to GATT characteristic
                         # inspection by briefly connecting to the device.
-                        if normalize_uuid_str(FTMS_UUID) not in adv.service_uuids:
-                            continue
-
                         try:
                             async with BleakClient(
                                 dev, services=[FTMS_UUID]

--- a/src/pyftms/client/__init__.py
+++ b/src/pyftms/client/__init__.py
@@ -6,10 +6,10 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
-from bleak import BleakScanner
+from bleak import BleakClient, BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
-from bleak.exc import BleakDeviceNotFoundError
+from bleak.exc import BleakError, BleakDeviceNotFoundError
 from bleak.uuids import normalize_uuid_str
 
 from .backends import (
@@ -32,6 +32,7 @@ from .properties import (
     MachineType,
     MovementDirection,
     SettingRange,
+    get_machine_type_from_gatt,
     get_machine_type_from_service_data,
 )
 
@@ -112,7 +113,27 @@ async def discover_ftms_devices(
                         machine_type = get_machine_type_from_service_data(adv)
 
                     except NotFitnessMachineError:
-                        continue
+                        # The device advertises the FTMS service UUID but does
+                        # not include machine type in its service data (e.g.
+                        # Bodytone DU30). Fall back to GATT characteristic
+                        # inspection by briefly connecting to the device.
+                        if normalize_uuid_str(FTMS_UUID) not in adv.service_uuids:
+                            continue
+
+                        try:
+                            async with BleakClient(
+                                dev, services=[FTMS_UUID]
+                            ) as cli:
+                                machine_type = await get_machine_type_from_gatt(
+                                    cli
+                                )
+                        except (BleakError, NotFitnessMachineError, OSError):
+                            _LOGGER.debug(
+                                "Could not determine machine type for '%s' "
+                                "via GATT fallback.",
+                                dev.address,
+                            )
+                            continue
 
                     devices.add(dev.address)
 

--- a/src/pyftms/client/client.py
+++ b/src/pyftms/client/client.py
@@ -242,7 +242,8 @@ class FitnessMachine(ABC, PropertiesManager):
     def _on_disconnect(self, cli: BleakClient) -> None:
         _LOGGER.debug("Client disconnected. Reset updaters states.")
 
-        del self._cli
+        if hasattr(self, "_cli"):
+            del self._cli
         self._updater.reset()
         self._controller.reset()
 

--- a/src/pyftms/client/properties/__init__.py
+++ b/src/pyftms/client/properties/__init__.py
@@ -9,10 +9,15 @@ from .features import (
     SettingRange,
     read_features,
 )
-from .machine_type import MachineType, get_machine_type_from_service_data
+from .machine_type import (
+  MachineType,
+  get_machine_type_from_gatt,
+  get_machine_type_from_service_data
+)
 
 __all__ = [
     "DeviceInfo",
+    "get_machine_type_from_gatt",
     "get_machine_type_from_service_data",
     "MachineFeatures",
     "MachineSettings",

--- a/src/pyftms/client/properties/machine_type.py
+++ b/src/pyftms/client/properties/machine_type.py
@@ -5,10 +5,17 @@ import functools
 import operator
 from enum import Flag, auto
 
+from bleak import BleakClient
 from bleak.backends.scanner import AdvertisementData
 from bleak.uuids import normalize_uuid_str
 
-from ..const import FTMS_UUID
+from ..const import (
+    CROSS_TRAINER_DATA_UUID,
+    FTMS_UUID,
+    INDOOR_BIKE_DATA_UUID,
+    ROWER_DATA_UUID,
+    TREADMILL_DATA_UUID,
+)
 from ..errors import NotFitnessMachineError
 
 
@@ -79,3 +86,31 @@ def get_machine_type_from_service_data(
         return mt
 
     raise NotFitnessMachineError(data)
+
+
+async def get_machine_type_from_gatt(cli: BleakClient) -> MachineType:
+    """Determines fitness machine type from connected GATT characteristics.
+
+    Used as a fallback when the device advertises the FTMS service UUID but
+    does not include machine type information in its advertisement service data
+    (e.g. Bodytone DU30).
+
+    Parameters:
+        cli: Connected `BleakClient` instance with FTMS service discovered.
+
+    Returns:
+        Fitness machine type.
+    """
+
+    _UUID_TO_TYPE = (
+        (TREADMILL_DATA_UUID, MachineType.TREADMILL),
+        (CROSS_TRAINER_DATA_UUID, MachineType.CROSS_TRAINER),
+        (ROWER_DATA_UUID, MachineType.ROWER),
+        (INDOOR_BIKE_DATA_UUID, MachineType.INDOOR_BIKE),
+    )
+
+    for uuid, machine_type in _UUID_TO_TYPE:
+        if cli.services.get_characteristic(uuid) is not None:
+            return machine_type
+
+    raise NotFitnessMachineError()


### PR DESCRIPTION
This pull request improves the ability of the FTMS device discovery process to correctly identify machine types, especially for devices that do not advertise their type in service data. The main enhancement is a fallback mechanism that inspects GATT characteristics if the machine type cannot be determined from advertisement data. Additionally, the new utility function for GATT-based type detection has been added and exported for broader use.

**Enhancements to FTMS device discovery:**

* Added a fallback mechanism in `discover_ftms_devices` to determine machine type by connecting to the device and inspecting its GATT characteristics when service data is insufficient. This increases compatibility with devices like the Bodytone DU30 that do not include machine type in their advertisements.

**New utility for machine type detection:**

* Implemented `get_machine_type_from_gatt`, an async function that determines the fitness machine type by checking for known FTMS data characteristics on a connected device.
* Exported `get_machine_type_from_gatt` in both `src/pyftms/client/properties/__init__.py` and `src/pyftms/client/__init__.py` for use elsewhere in the codebase. [[1]](diffhunk://#diff-7846896d1aa06323f9d8dad3a9a18edc0e85ca985898112d75745966fcdbdb57L12-R20) [[2]](diffhunk://#diff-c10fe1af6238516d16c2c62ac0c394e07700d47bdaee4f520eeda8d02281598eR35)

**Dependency and import updates:**

* Updated imports in several modules to include `BleakClient`, `BleakError`, and the new utility function, ensuring all necessary components are available for the new fallback logic. [[1]](diffhunk://#diff-c10fe1af6238516d16c2c62ac0c394e07700d47bdaee4f520eeda8d02281598eL9-R12) [[2]](diffhunk://#diff-02862fa5cf482a945a5931486f0221ad5aeaeae9b76236637b70e9c4edaf30bfR8-R18)